### PR TITLE
Cni tap instead of internal

### DIFF
--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -354,6 +354,10 @@ func (h *NetworkUtilsHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceNa
 }
 
 func (h *NetworkUtilsHandler) CreateTapDevice(tapName string, queueNumber uint32, launcherPID int, mtu int, tapOwner string) error {
+	// Secondary networks do not require tap creation, as the CNI tap plugin should have created it already.
+	if tapName != "tap0" {
+		return nil
+	}
 	tapDeviceSELinuxCmdExecutor, err := buildTapDeviceMaker(tapName, queueNumber, launcherPID, mtu, tapOwner)
 	if err != nil {
 		return err

--- a/pkg/virt-controller/services/multus_annotations.go
+++ b/pkg/virt-controller/services/multus_annotations.go
@@ -71,8 +71,8 @@ func GenerateMultusCNIAnnotationFromNameScheme(namespace string, interfaces []v1
 	for _, network := range networks {
 		if vmispec.IsSecondaryMultusNetwork(network) {
 			podInterfaceName := networkNameScheme[network.Name]
-			multusNetworkAnnotationPool.add(
-				newMultusAnnotationData(namespace, interfaces, network, podInterfaceName))
+			vmiIface := vmispec.LookupInterfaceByName(interfaces, network.Name)
+			multusNetworkAnnotationPool.add(newMultusAnnotationData(namespace, vmiIface, network, podInterfaceName))
 		}
 	}
 
@@ -82,12 +82,11 @@ func GenerateMultusCNIAnnotationFromNameScheme(namespace string, interfaces []v1
 	return "", nil
 }
 
-func newMultusAnnotationData(namespace string, interfaces []v1.Interface, network v1.Network, podInterfaceName string) multusNetworkAnnotation {
-	multusIface := vmispec.LookupInterfaceByName(interfaces, network.Name)
+func newMultusAnnotationData(namespace string, iface *v1.Interface, network v1.Network, podInterfaceName string) multusNetworkAnnotation {
 	namespace, networkName := getNamespaceAndNetworkName(namespace, network.Multus.NetworkName)
 	var multusIfaceMac string
-	if multusIface != nil {
-		multusIfaceMac = multusIface.MacAddress
+	if iface != nil {
+		multusIfaceMac = iface.MacAddress
 	}
 	return multusNetworkAnnotation{
 		InterfaceName: podInterfaceName,

--- a/pkg/virt-controller/services/multus_annotations_test.go
+++ b/pkg/virt-controller/services/multus_annotations_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Multus annotations", func() {
 
 		It("when added an element, is no longer empty", func() {
 			podIfaceName := "net1"
-			multusAnnotationPool.add(newMultusAnnotationData(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, network, podIfaceName))
+			multusAnnotationPool.add(newMultusAnnotationData(vmi.Namespace, nil, network, podIfaceName))
 			Expect(multusAnnotationPool.isEmpty()).To(BeFalse())
 		})
 
@@ -70,7 +70,7 @@ var _ = Describe("Multus annotations", func() {
 		BeforeEach(func() {
 			multusAnnotationPool = multusNetworkAnnotationPool{
 				pool: []multusNetworkAnnotation{
-					newMultusAnnotationData(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, network, "net1"),
+					newMultusAnnotationData(vmi.Namespace, nil, network, "net1"),
 				},
 			}
 		})

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -986,8 +986,11 @@ var _ = Describe("Template", func() {
 				Expect(ok).To(BeTrue())
 				expectedIfaces := ("[" +
 					"{\"interface\":\"pod37a8eec1ce1\",\"name\":\"default\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"tap37a8eec1ce1\",\"name\":\"kubevirt-tap\",\"namespace\":\"default\"}," +
 					"{\"interface\":\"pod1b4f0e98519\",\"name\":\"test1\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"pod49dba5c72f0\",\"name\":\"test1\",\"namespace\":\"other-namespace\"}" +
+					"{\"interface\":\"tap1b4f0e98519\",\"name\":\"kubevirt-tap\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"pod49dba5c72f0\",\"name\":\"test1\",\"namespace\":\"other-namespace\"}," +
+					"{\"interface\":\"tap49dba5c72f0\",\"name\":\"kubevirt-tap\",\"namespace\":\"default\"}" +
 					"]")
 				Expect(value).To(Equal(expectedIfaces))
 			})
@@ -1026,7 +1029,7 @@ var _ = Describe("Template", func() {
 				Expect(value).To(Equal("default"))
 				value, ok = pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(BeTrue())
-				Expect(value).To(Equal("[{\"interface\":\"pod1b4f0e98519\",\"name\":\"test1\",\"namespace\":\"default\"}]"))
+				Expect(value).To(Equal("[{\"interface\":\"pod1b4f0e98519\",\"name\":\"test1\",\"namespace\":\"default\"},{\"interface\":\"tap1b4f0e98519\",\"name\":\"kubevirt-tap\",\"namespace\":\"default\"}]"))
 			})
 			It("should add MAC address in the pod annotation", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -1071,7 +1074,9 @@ var _ = Describe("Template", func() {
 				Expect(ok).To(BeTrue())
 				expectedIfaces := ("[" +
 					"{\"interface\":\"pod37a8eec1ce1\",\"name\":\"default\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"pod1b4f0e98519\",\"mac\":\"de:ad:00:00:be:af\",\"name\":\"test1\",\"namespace\":\"default\"}" +
+					"{\"interface\":\"tap37a8eec1ce1\",\"name\":\"kubevirt-tap\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"pod1b4f0e98519\",\"mac\":\"de:ad:00:00:be:af\",\"name\":\"test1\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"tap1b4f0e98519\",\"name\":\"kubevirt-tap\",\"namespace\":\"default\"}" +
 					"]")
 				Expect(value).To(Equal(expectedIfaces))
 			})
@@ -1122,13 +1127,17 @@ var _ = Describe("Template", func() {
 						networkv1.NetworkStatusAnnot: `[
 							{"interface":"eth0", "name":"default"},
 							{"interface":"net1", "name":"test1", "namespace":"default"},
-							{"interface":"net2", "name":"test1", "namespace":"other-namespace"}
+							{"interface":"pod1", "name":"kubevirt-tap", "namespace":"default"},
+							{"interface":"net2", "name":"test1", "namespace":"other-namespace"},
+							{"interface":"pod2", "name":"kubevirt-tap", "namespace":"default"}
 						]`,
 					},
 					map[string]string{
 						MultusNetworksAnnotation: `[
 							{"interface":"net1", "name":"test1", "namespace":"default"},
-							{"interface":"net2", "name":"test1", "namespace":"other-namespace"}
+							{"interface":"tap1", "name":"kubevirt-tap", "namespace":"default"},
+							{"interface":"net2", "name":"test1", "namespace":"other-namespace"},
+							{"interface":"tap2", "name":"kubevirt-tap", "namespace":"default"}
 						]`,
 					},
 				),
@@ -1136,13 +1145,17 @@ var _ = Describe("Template", func() {
 					map[string]string{
 						networkv1.NetworkStatusAnnot: `[
 							{"interface":"pod16477688c0e", "name":"test1", "namespace":"default"},
-							{"interface":"podb1f51a511f1", "name":"test1", "namespace":"other-namespace"}
+							{"interface":"tap16477688c0e", "name":"kubevirt-tap", "namespace":"default"},
+							{"interface":"podb1f51a511f1", "name":"test1", "namespace":"other-namespace"},
+							{"interface":"tapb1f51a511f1", "name":"kubevirt-tap", "namespace":"default"}
 						]`,
 					},
 					map[string]string{
 						MultusNetworksAnnotation: `[
 							{"interface":"pod16477688c0e", "name":"test1", "namespace":"default"},
-							{"interface":"podb1f51a511f1", "name":"test1", "namespace":"other-namespace"}
+							{"interface":"tap16477688c0e", "name":"kubevirt-tap", "namespace":"default"},
+							{"interface":"podb1f51a511f1", "name":"test1", "namespace":"other-namespace"},
+							{"interface":"tapb1f51a511f1", "name":"kubevirt-tap", "namespace":"default"}
 						]`,
 					},
 				),

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -3208,7 +3208,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,
-						`[{"interface":"pod7e0055a6880","name":"net1","namespace":"default"}]`)),
+						`[{"interface":"pod7e0055a6880","name":"net1","namespace":"default"},{"interface":"tap7e0055a6880","name":"kubevirt-tap","namespace":"default"}]`)),
 				Entry("hotplug multiple interfaces",
 					[]virtv1.AddInterfaceOptions{{
 						NetworkAttachmentDefinitionName: "net1",
@@ -3219,7 +3219,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,
-						`[{"interface":"pod7e0055a6880","name":"net1","namespace":"default"},{"interface":"pod48802102d24","name":"net1","namespace":"default"}]`)),
+						`[{"interface":"pod7e0055a6880","name":"net1","namespace":"default"},{"interface":"tap7e0055a6880","name":"kubevirt-tap","namespace":"default"},{"interface":"pod48802102d24","name":"net1","namespace":"default"},{"interface":"tap48802102d24","name":"kubevirt-tap","namespace":"default"}]`)),
 			)
 			DescribeTable("the subject interface name, in the pod networks annotation, should be in similar form as other interfaces",
 				func(testPodNetworkStatus []networkv1.NetworkStatus, expectedMultusNetworksAnnotation string) {
@@ -3258,7 +3258,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					// expected Multus network annotation
 					`[
 							{"interface":"net1", "name":"red-net", "namespace": "default"},
-							{"interface":"net2", "name":"blue-net", "namespace": "default"}
+							{"interface":"tap1", "name":"kubevirt-tap", "namespace": "default"},
+							{"interface":"net2", "name":"blue-net", "namespace": "default"},
+							{"interface":"tap2", "name":"kubevirt-tap", "namespace": "default"}
 					]`,
 				),
 				Entry("when Multus network-status annotation interfaces has hashed names",
@@ -3270,7 +3272,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					// expected Multus network annotation
 					`[
 							{"interface":"podb1f51a511f1", "name":"red-net", "namespace": "default"},
-							{"interface":"pod16477688c0e", "name":"blue-net", "namespace": "default"}
+							{"interface":"tapb1f51a511f1", "name":"kubevirt-tap", "namespace": "default"},
+							{"interface":"pod16477688c0e", "name":"blue-net", "namespace": "default"},
+							{"interface":"tap16477688c0e", "name":"kubevirt-tap", "namespace": "default"}
 					]`,
 				),
 			)

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -448,7 +448,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 				libwait.WaitUntilVMIReady(vmiTwo, console.LoginToFedora)
 			})
 
-			It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", func() {
+			FIt("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", func() {
 				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
 				linuxBridgeInterfaceWithCustomMac := linuxBridgeInterface
 				linuxBridgeInterfaceWithCustomMac.MacAddress = customMacAddress


### PR DESCRIPTION
**What this PR does / why we need it**:

PoC for using the CNI tap plugin [1] instead of creating the device by the virt-handler.

Currently, it works only for secondary networks.

Tested locally successfully with SELinux **disabled**.

[1] https://www.cni.dev/plugins/current/main/tap/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
